### PR TITLE
BUG: Add EXCLUDE_FROM_DEFAULT.

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -10,4 +10,5 @@ itk_module(IOSTL
     ITKQuadEdgeMesh
   DESCRIPTION
     "${DOCUMENTATION}"
+  EXCLUDE_FROM_DEFAULT
 )


### PR DESCRIPTION
As a Remote Module, EXCLUDE_FROM_DEFAULT needs to be added from the module
being inadvertently turned on in a fresh build after it was downloaded in a
previous build.

This is causing Nightly External builds to fail:

  http://open.cdash.org/viewTest.php?onlyfailed&buildid=3197820
