### PR TITLE
BUG: Fix WritePointsTyped() to no longer use conflicting typenames

### DIFF
--- a/include/itkSTLMeshIO.h
+++ b/include/itkSTLMeshIO.h
@@ -135,8 +135,8 @@ protected:
 
   /** Templated version of write points method, that is aware of the specific
    * type used to represent the point coordinates. */
-  template< typename PointValueType >
-  void WritePointsTyped( const PointValueType * buffer )
+  template< typename TPointsBuffer >
+  void WritePointsTyped( const TPointsBuffer * const buffer )
   {
 
     const unsigned int pointDimension = this->GetPointDimension();
@@ -146,7 +146,7 @@ protected:
       itkExceptionMacro("STL only supports 3D points");
       }
 
-    const PointValueType * pointCoordinates = buffer;
+    const TPointsBuffer * pointCoordinates = buffer;
 
     this->m_Points.clear();
 
@@ -158,7 +158,7 @@ protected:
       {
       for( unsigned int i = 0; i < pointDimension; ++i )
         {
-        m_Points[pi][i] = *pointCoordinates++;
+        m_Points[pi][i] = static_cast< PointValueType >( *pointCoordinates++ );
         }
       }
 


### PR DESCRIPTION
"PointValueType" was both the template parmeter of WritePointsTyped() and
a typedef of the enclosing class. This was generating errors with GCC on
OSX. Renamed the template parameter to "TPointsBuffer" to fix this error.

Also added a static_cast to make the conversion to the internal value type
explicit.

Also made the parameter for WritePointsTyped() a const pointer to const
values, to clarify its intended use as an input buffer.
